### PR TITLE
Add support for a custom data dir for Linux system installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(Kroniax)
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
 set(SFML_STATIC_LIBS FALSE CACHE BOOL "Choose whether SFML is linked statically or not.")
 set(KRONIAX_STATIC_STD_LIBS FALSE CACHE BOOL "Use statically linked standard/runtime libraries? This option must match the one used for SFML.")
+set(KRONIAX_DATADIR CACHE STRING "Optional path to a custom data directory (if not provided, data will be loaded from ./data.")
     
 # Make sure that the runtime library gets link statically
 if(KRONIAX_STATIC_STD_LIBS)
@@ -23,6 +24,10 @@ if(KRONIAX_STATIC_STD_LIBS)
                 # Note: Doesn't work for TDM compiler, since it's compiling the runtime libs statically by default
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
         endif()
+endif()
+
+if(KRONIAX_DATADIR)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDATADIR=\\\"${KRONIAX_DATADIR}\\\"")
 endif()
 
 # Kroniax uses C++11 features

--- a/include/global.hpp
+++ b/include/global.hpp
@@ -1,0 +1,18 @@
+#ifndef GLOBAL_HPP
+#define GLOBAL_HPP
+
+#include <string>
+
+#ifndef DATADIR
+#define DATADIR "./data"
+#endif // DATADIR
+
+namespace Helper
+{
+	inline std::string getData(const std::string& filePath)
+	{
+		return std::string(DATADIR) + "/" + filePath;
+	}
+}
+
+#endif // GLOBAL_HPP

--- a/include/modules/chatHandler.cpp
+++ b/include/modules/chatHandler.cpp
@@ -2,6 +2,7 @@
 
 #include <SFML/Graphics/RenderTarget.hpp>
 
+#include "../global.hpp"
 #include "../utilities/hash.hpp"
 #include "../messageBus/messageBus.hpp"
 
@@ -13,7 +14,7 @@ namespace aw
 	{
 		m_messageBus.addReceiver(this);
 
-		mFont.loadFromFile("data/fonts/visitor1.ttf");
+		mFont.loadFromFile(Helper::getData("fonts/visitor1.ttf"));
 
 		mSourundingRect.setPosition(sf::Vector2f(5, 145));
 		mSourundingRect.setSize(sf::Vector2f(790, 300));

--- a/include/modules/game/countdown.cpp
+++ b/include/modules/game/countdown.cpp
@@ -1,5 +1,7 @@
 #include "countdown.hpp"
 
+#include "../../global.hpp"
+
 #include <sstream>
 
 #include <SFML/Graphics/RenderWindow.hpp>
@@ -10,7 +12,7 @@ namespace aw
 	Countdown::Countdown() :
 		m_timeLeft(0.f)
 	{
-		m_font.loadFromFile("data/fonts/visitor1.ttf");
+		m_font.loadFromFile(Helper::getData("fonts/visitor1.ttf"));
 		m_text.setFont(m_font);
 		m_text.setPosition(300, 5);
 		m_text.setCharacterSize(15);

--- a/include/modules/game/gameTimer.cpp
+++ b/include/modules/game/gameTimer.cpp
@@ -1,5 +1,7 @@
 #include "gameTimer.hpp"
 
+#include "../../global.hpp"
+
 #include <sstream>
 
 #include <SFML/Graphics/RenderWindow.hpp>
@@ -9,7 +11,7 @@ namespace aw
 	GameTimer::GameTimer() :
 		m_elapsedTime(0)
 	{
-		m_font.loadFromFile("data/fonts/visitor1.ttf");
+		m_font.loadFromFile(Helper::getData("fonts/visitor1.ttf"));
 		m_text.setFont(m_font);
 		m_text.setPosition(10, 415);
 		m_text.setCharacterSize(23);

--- a/include/modules/game/playerHUD.cpp
+++ b/include/modules/game/playerHUD.cpp
@@ -1,6 +1,7 @@
 #include "playerHUD.hpp"
 
 #include "player.hpp"
+#include "../../global.hpp"
 
 #include <sstream>
 
@@ -10,7 +11,7 @@ namespace aw
 {
 	PlayerHUD::PlayerHUD()
 	{
-		m_font.loadFromFile("data/fonts/visitor1.ttf");
+		m_font.loadFromFile(Helper::getData("fonts/visitor1.ttf"));
 		m_displaySpeed.setFont(m_font);
 		m_displaySpeed.setColor(sf::Color::White);
 		m_displaySpeed.setCharacterSize(18);

--- a/include/modules/game/timeTable.cpp
+++ b/include/modules/game/timeTable.cpp
@@ -1,5 +1,7 @@
 #include "timeTable.hpp"
 
+#include "../../global.hpp"
+
 #include <sstream>
 
 #include <SFML/Graphics/RenderWindow.hpp>
@@ -11,7 +13,7 @@ namespace aw
 {
 	TimeTable::TimeTable()
 	{
-		m_font.loadFromFile("data/fonts/visitor1.ttf");
+		m_font.loadFromFile(Helper::getData("fonts/visitor1.ttf"));
 	}
 
 	void TimeTable::addPlayer(const std::string &name, float time, const sf::Color &color)

--- a/include/modules/settings.cpp
+++ b/include/modules/settings.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <sstream>
 
+#include "../global.hpp"
 #include "../utilities/hash.hpp"
 #include "../messageBus/messageBus.hpp"
 
@@ -22,7 +23,7 @@ namespace aw
 
 	void Settings::save()
 	{
-		std::fstream file("data/config.cfg", std::ios::out | std::ios::trunc);
+		std::fstream file(Helper::getData("config.cfg"), std::ios::out | std::ios::trunc);
 		file << "Config file for the game Kroniax\n";
 
 		//Save window settings
@@ -51,7 +52,7 @@ namespace aw
 		file.close();
 
 		//Arcade levellist
-		file.open("data/arcade levellist.cfg", std::ios::out | std::ios::trunc);
+		file.open(Helper::getData("arcade levellist.cfg"), std::ios::out | std::ios::trunc);
 
 		file << m_arcadeSettings.unlockValue << "\n";
 		for (auto &it : m_arcadeSettings.levelList)
@@ -64,7 +65,7 @@ namespace aw
 
 	void Settings::loadWindowAndSoundSettings()
 	{
-		std::fstream file("data/config.cfg", std::ios::in);
+		std::fstream file(Helper::getData("config.cfg"), std::ios::in);
 		std::string line;
 
 		while (std::getline(file, line))
@@ -110,7 +111,7 @@ namespace aw
 
 	void Settings::loadArcadeSettings()
 	{
-		std::fstream file("data/arcade levellist.cfg", std::ios::in);
+		std::fstream file(Helper::getData("arcade levellist.cfg"), std::ios::in);
 		std::string line;
 
 		//First line = unlocked levels

--- a/include/modules/states/game.cpp
+++ b/include/modules/states/game.cpp
@@ -8,6 +8,7 @@
 #include <SFML/Graphics/RenderWindow.hpp>
 #include <SFML/Window/Event.hpp>
 
+#include "../../global.hpp"
 #include "../../messageBus/messageBus.hpp"
 #include "../../utilities/hash.hpp"
 #include "../../modules/chatHandler.hpp"
@@ -28,7 +29,7 @@ namespace aw
 		m_openMusic(-1)
 	{
 		m_messageBus.addReceiver(this);
-		m_gui.loadFont("data/fonts/visitor1.ttf");
+		m_gui.loadFont(Helper::getData("fonts/visitor1.ttf"));
 
 		initGui(m_gui); //Global Function
 	}
@@ -617,21 +618,21 @@ namespace aw
 			if (levelnumber < 6)
 			{
 				if (m_openMusic != 0)
-					m_music.openFromFile("data/music/Galaxy - New Electro House Techno by MafiaFLairBeatz.ogg");
+					m_music.openFromFile(Helper::getData("music/Galaxy - New Electro House Techno by MafiaFLairBeatz.ogg"));
 
 				m_openMusic = 0;
 			}
 			else if (levelnumber < 11)
 			{
 				if (m_openMusic != 1)
-					m_music.openFromFile("data/music/MachinimaSound.com_-_After_Dark.ogg");
+					m_music.openFromFile(Helper::getData("music/MachinimaSound.com_-_After_Dark.ogg"));
 
 				m_openMusic = 1;
 			}
 			else if (levelnumber < 16)
 			{
 				if (m_openMusic != 2)
-					m_music.openFromFile("data/music/MachinimaSound.com_-_Queen_of_the_Night.ogg");
+					m_music.openFromFile(Helper::getData("music/MachinimaSound.com_-_Queen_of_the_Night.ogg"));
 
 				m_openMusic = 2;
 			}
@@ -648,12 +649,12 @@ namespace aw
 	
 			switch (musicNumber)
 			{
-			case 0: m_music.openFromFile("data/music/Galaxy - New Electro House Techno by MafiaFLairBeatz.ogg"); break;
-			case 1: m_music.openFromFile("data/music/Infinity - Techno Trance Project 2011 by MafiaFLairBeatz.ogg"); break;
-			case 2: m_music.openFromFile("data/music/MachinimaSound.com_-_After_Dark.ogg"); break;
-			case 3: m_music.openFromFile("data/music/MachinimaSound.com_-_Queen_of_the_Night.ogg"); break;
-			case 4: m_music.openFromFile("data/music/Power Fight - Electro Techno Beat.ogg"); break;
-			case 5: m_music.openFromFile("data/music/Return of the Electro by MafiaFLairBeatz.ogg"); break;
+			case 0: m_music.openFromFile(Helper::getData("music/Galaxy - New Electro House Techno by MafiaFLairBeatz.ogg")); break;
+			case 1: m_music.openFromFile(Helper::getData("music/Infinity - Techno Trance Project 2011 by MafiaFLairBeatz.ogg")); break;
+			case 2: m_music.openFromFile(Helper::getData("music/MachinimaSound.com_-_After_Dark.ogg")); break;
+			case 3: m_music.openFromFile(Helper::getData("music/MachinimaSound.com_-_Queen_of_the_Night.ogg")); break;
+			case 4: m_music.openFromFile(Helper::getData("music/Power Fight - Electro Techno Beat.ogg")); break;
+			case 5: m_music.openFromFile(Helper::getData("music/Return of the Electro by MafiaFLairBeatz.ogg")); break;
 			default: break;
 			}
 		}
@@ -676,11 +677,11 @@ namespace aw
 		std::string path;
 		if (m_gameType == GameType::OFFICIAL_ARCADE || m_gameType == GameType::OFFICIAL_TIMECHALLENGE)
 		{
-			path = "data/levels/official/" + m_levelName + ".cfg";
+			path = Helper::getData("levels/official/" + m_levelName + ".cfg");
 		}
 		else
 		{
-			path = "data/levels/custom/" + m_levelName + ".cfg";
+			path = Helper::getData("levels/custom/" + m_levelName + ".cfg");
 		}
 
 		//Load all modules

--- a/include/modules/states/intro.cpp
+++ b/include/modules/states/intro.cpp
@@ -1,5 +1,7 @@
 #include "intro.hpp"
 
+#include "../../global.hpp"
+
 #include <SFML/System/Time.hpp>
 #include <SFML/Graphics/RenderWindow.hpp>
 
@@ -11,7 +13,7 @@ namespace aw
 	Intro::Intro(StateMachine &stateMachine):
 		State(stateMachine), m_timeActive(0)
 	{
-		m_texLogo.loadFromFile("data/images/kroniax.png");
+		m_texLogo.loadFromFile(Helper::getData("images/kroniax.png"));
 		m_sprLogo.setTexture(m_texLogo);
 		m_sprLogo.setPosition(95, -40);
 		m_sprLogo.setColor(sf::Color(255, 255, 255, 255));

--- a/include/modules/states/menu.cpp
+++ b/include/modules/states/menu.cpp
@@ -1,5 +1,6 @@
 #include "menu.hpp"
 
+#include "../../global.hpp"
 #include "../../messageBus/messageBus.hpp"
 #include "../../utilities/hash.hpp"
 
@@ -39,19 +40,19 @@ namespace aw
 		m_overlay.setSize(sf::Vector2f(800.f, 450.f));
 		m_overlay.setFillColor(sf::Color(0, 0, 0, 180));
 
-		m_texLogo.loadFromFile("data/images/kroniax.png");
+		m_texLogo.loadFromFile(Helper::getData("images/kroniax.png"));
 		m_logo.setTexture(m_texLogo);
 		m_logo.setScale(0.6f, 0.6f);
 		m_logo.setPosition(215.f, -25.f);
 
 		resetView();
 
-		m_music.openFromFile("data/music/Power Fight - Electro Techno Beat.ogg");
+		m_music.openFromFile(Helper::getData("music/Power Fight - Electro Techno Beat.ogg"));
 	}
 
 	void Menu::initGui()
 	{
-		m_gui.loadFont("data/fonts/visitor1.ttf");
+		m_gui.loadFont(Helper::getData("fonts/visitor1.ttf"));
 
 		//Layer 0
 		initMainLayer(m_gui);
@@ -242,7 +243,7 @@ namespace aw
 		int levelNumber = uniform_dist(e1);
 		std::stringstream sstr;
 		sstr << levelNumber;
-		std::string path = "data/levels/old levels/Level" + sstr.str() + "_old.cfg";
+		std::string path = Helper::getData("levels/old levels/Level" + sstr.str() + "_old.cfg");
 		m_mapRenderer.load(path);
 	}
 
@@ -285,7 +286,7 @@ namespace aw
 			//Check if update is needed
 			if (m_levelInformation.name != name)
 			{
-				std::fstream file(("data/levels/official/" + name + ".cfg").c_str());
+				std::fstream file((Helper::getData("levels/official/" + name + ".cfg")).c_str());
 
 				if (file.good())
 				{


### PR DESCRIPTION
An optional KRONIAX_DATADIR parameter can be passed to CMake to initialise
a custom data dir (e.g. /usr/share/games/kroniax for system-wide installs
on Linux). If the optional parameter is not passed, the data dir defaults
to "./data" as previously.

To achieve this, a Helper::getData function has been added in new global.hpp
header, which can be accessed from any source file that requires access to
data files.

Fixes #16.